### PR TITLE
Git: Fix typo in `--autostash` parameter

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/git/GitCommandFacade.kt
+++ b/src/org/jetbrains/kotlin/test/helper/git/GitCommandFacade.kt
@@ -162,7 +162,7 @@ object Git {
         coroutineToIndicator {
             git.runCommand {
                 GitLineHandler(project, repository.root, GitCommand.REBASE).apply {
-                    if (autoStash) addParameters("--autosquash")
+                    if (autoStash) addParameters("--autostash")
                     addParameters(revision)
                 }
             }.success()


### PR DESCRIPTION
Just a dumb typo fix