### PR TITLE
82 related files

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
+++ b/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
@@ -70,6 +70,7 @@ val String.asPathWithoutAllExtensions: String
     }
 
 val VirtualFile.nameWithoutAllExtensions get() = name.asPathWithoutAllExtensions
+val VirtualFile.allExtensions get() = name.substring(nameWithoutAllExtensions.length)
 
 fun AnActionEvent.toFileNamesString(): String? {
     val project = project ?: return null

--- a/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
+++ b/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
@@ -35,6 +35,7 @@ enum class TestDataType {
     File,
     Directory,
     DirectoryOfFiles,
+    RelatedFile,
 }
 
 fun VirtualFile.getTestDataType(project: Project): TestDataType? {
@@ -44,6 +45,7 @@ fun VirtualFile.getTestDataType(project: Project): TestDataType? {
         return when {
             extension in supportedExtensions -> TestDataType.File
             isDirectory -> TestDataType.DirectoryOfFiles
+            supportedExtensions.any { parent.findChild("$nameWithoutAllExtensions.$it") != null } -> TestDataType.RelatedFile
             else -> null
         }
     }

--- a/src/org/jetbrains/kotlin/test/helper/ui/TestDataEditor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/ui/TestDataEditor.kt
@@ -26,6 +26,7 @@ import com.intellij.util.SingleAlarm
 import com.intellij.util.ui.JBUI
 import org.jetbrains.kotlin.test.helper.actions.ChooseAdditionalFileAction
 import org.jetbrains.kotlin.test.helper.actions.GeneratedTestComboBoxAction
+import org.jetbrains.kotlin.test.helper.allExtensions
 import org.jetbrains.kotlin.test.helper.state.PreviewEditorState
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
@@ -45,7 +46,7 @@ class TestDataEditor(
 
     private val previewEditorState: PreviewEditorState = PreviewEditorState(
         baseEditor,
-        PropertiesComponent.getInstance().getValue(lastUsedPreviewPropertyName)?.toIntOrNull() ?: 0,
+        PropertiesComponent.getInstance().getValue(lastUsedPreviewPropertyName),
         this,
     )
 
@@ -108,7 +109,7 @@ class TestDataEditor(
         PropertiesComponent.getInstance()
             .setValue(
                 lastUsedPreviewPropertyName,
-                previewEditorState.currentPreviewIndex.toString()
+                previewEditorState.currentPreview.file.allExtensions
             )
         baseEditor.component.isVisible = true
         previewEditorState.currentPreview.component.isVisible = editorViewMode == EditorViewMode.BaseAndAdditionalEditor


### PR DESCRIPTION
This change enables using related files (dumps, .fir versions, etc) as tests in UI. 
In particular:
* They now have a test editor and run test buttons because of it
* They can be used to run tests when selected in different file views. 